### PR TITLE
Update to sequelize v3

### DIFF
--- a/README-JSDOC-TR.md
+++ b/README-JSDOC-TR.md
@@ -638,7 +638,7 @@ Template içerisinde kullanılacak olan değişkenler ve açıklamaları aşağ�
         <td>İlişkinin referans ettiği tablonun ismi.</td>
     </tr>
     <tr>
-        <td>table.hasManies[n].foreignKey</td>
+        <td>table.hasManies[n].key</td>
         <td>İlişkinin referans ettiği tablodaki yabancı anahtar alanının ismi.</td>
     </tr>
     <tr>

--- a/README-JSDOC.md
+++ b/README-JSDOC.md
@@ -642,7 +642,7 @@ Variables available to use in templates are listed below. Please note if a value
         <td>Table name which this table refers to.</td>
     </tr>
     <tr>
-        <td>table.hasManies[n].foreignKey</td>
+        <td>table.hasManies[n].key</td>
         <td>Foreign key column name in the target table.</td>
     </tr>
     <tr>

--- a/README-TR.md
+++ b/README-TR.md
@@ -686,7 +686,7 @@ Template içerisinde kullanılacak olan değişkenler ve açıklamaları aşağ�
         <td>İlişkinin referans ettiği tablonun ismi.</td>
     </tr>
     <tr>
-        <td>table.belongsTos[n].foreignKey</td>
+        <td>table.belongsTos[n].key</td>
         <td>Bu tablodaki bu ilişkiye ait olan yabancı anahtar alanının ismi.</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Variables available to use in templates are listed below. Please note if a value
         <td>If this column has a reference, this value is the name of table which this column references to.</td>
     </tr>
     <tr>
-        <td>table.columns[n].referencesKey</td>
+        <td>table.columns[n].key</td>
         <td>If this column has a reference, this value is the name of foreign key which this column references to.</td>
     </tr>
     <tr>

--- a/doc/lib_index.js.html
+++ b/doc/lib_index.js.html
@@ -365,7 +365,7 @@ function getColumnDetails(column) {
         unique              : column.unique(),
         comment             : getSpecificConfig(column.table().name(), 'generate.columnDescription') ? column.description() : undefined,
         references          : column.foreignKeyConstraint() ? column.foreignKeyConstraint().referencesTable().name() : undefined,
-        referencesKey       : column.foreignKeyConstraint() ? column.foreignKeyConstraint().foreignKey(0).name() : undefined,
+	key		    : column.foreignKeyConstraint() ? column.foreignKeyConstraint().foreignKey(0).name() : undefined,
         onUpdate            : column.onUpdate(),
         onDelete            : column.onDelete()
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -292,7 +292,7 @@ function getColumnDetails(column) {
         unique              : column.unique(),
         comment             : getSpecificConfig(column.table().name(), 'generate.columnDescription') ? column.description() : undefined,
         references          : column.foreignKeyConstraint() ? column.foreignKeyConstraint().referencesTable().name() : undefined,
-        referencesKey       : column.foreignKeyConstraint() ? column.foreignKeyConstraint().foreignKey(0).name() : undefined,
+        key                 : column.foreignKeyConstraint() ? column.foreignKeyConstraint().foreignKey(0).name() : undefined,
         onUpdate            : column.onUpdate(),
         onDelete            : column.onDelete()
     });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha": "^2.1.0",
     "pg": "^4.1.1",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^2.1.0"
+    "sequelize": "^3.1.0"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/template/column.html
+++ b/template/column.html
@@ -10,7 +10,7 @@
     {{ ifTrue('unique', column.unique) }}
     {{ ifTrue('comment', column.comment) }}
     {{ ifTrue('references', column.references) }}
-    {{ ifTrue('referencesKey', column.referencesKey) }}
+    {{ ifTrue('key', column.key) }}
     {{ ifTrue('onUpdate', column.onUpdate) }}
     {{ ifTrue('onDelete', column.onDelete) }}
 }


### PR DESCRIPTION
Update [Sequelize to v3](https://github.com/sequelize/sequelize/blob/master/changelog.md)

CHANGED : The references property of model attributes has been transformed to an object: {type: Sequelize.INTEGER, references: { model: SomeModel, key: 'some_key' }}.