### PR TITLE
Adding support for boolean default column value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,20 +128,25 @@ function filterAttributes(obj) {
  * Clears SQL type escapes (Two quote '' to one quote ') and strips beginning and trailing quotes around string.
  * @private
  * @param {string} string - Default
- * @returns {string|undefined}
+ * @returns {string|boolean|undefined}
  * @example
  * var clear = clearDefaultValue("'No ''value'' given'");
  * console.log(clear);    // No value 'given'
  */
 function clearDefaultValue(string) {
     // Does not support SQL functions. IMHO it is better to handle sql function default values in RDMS.
+    var defaultValue = undefined, lowercaseString, booleanValue;
     if (string.charAt(0) === "'" || string.charAt(0) === '"') {
         string = string.substring(1, string.length - 1);
-        string = string.replace(/''/g, "'");
+        defaultValue = string.replace(/''/g, "'");
     } else {
-        return undefined;
+        lowercaseString = string.toLowerCase()
+        booleanValue = (lowercaseString === 'true');
+        if (booleanValue || lowercaseString === 'false') {
+            defaultValue = booleanValue;
+        }
     }
-    return string;
+    return defaultValue;
 }
 
 

--- a/template/column.html
+++ b/template/column.html
@@ -6,7 +6,7 @@
     {{ ifTrue('primaryKey', column.primaryKey) }}
     {{ ifTrue('autoIncrement', column.autoIncrement) }}
     {{ ifFalse('allowNull', column.allowNull) }}
-    {{ ifTrue('defaultValue', column.defaultValue) }}
+    {{ ifNotUndefined('defaultValue', column.defaultValue) }}
     {{ ifTrue('unique', column.unique) }}
     {{ ifTrue('comment', column.comment) }}
     {{ ifTrue('references', column.references) }}

--- a/template/index.html
+++ b/template/index.html
@@ -39,6 +39,12 @@ module.exports = model;
     {% endif %}
 {% endmacro %}
 
+{% macro ifNotUndefined(label, value) %}
+    {% if value !== undefined %}
+        ,{{ label }}: {{ value }}
+    {% endif %}
+{% endmacro %}
+
 {% include "./table.html" %}
 
 {% endautoescape %}

--- a/test/generate-different-config.js
+++ b/test/generate-different-config.js
@@ -48,4 +48,10 @@ describe('account', function () {
             assert.isFalse(found);
         });
     });
+    it('should have true as default value for is_active', function() {
+        assert.equal(account.attributes.is_active.defaultValue, true);
+    });
+    it('should have false as default value for def_false', function() {
+        assert.equal(account.attributes.def_false.defaultValue, false);
+    });
 });

--- a/test/util/create-test-db-1.sql
+++ b/test/util/create-test-db-1.sql
@@ -199,6 +199,7 @@ CREATE TABLE account (
     updated_at timestamp(0) without time zone DEFAULT now() NOT NULL,
     owner_id integer,
     is_active boolean DEFAULT true NOT NULL,
+    def_false boolean DEFAULT false NOT NULL,
     name character varying(50) NOT NULL,
     field1 character varying(2)[],
     field2 numeric(3,2)[],
@@ -913,10 +914,10 @@ SET search_path = public, pg_catalog;
 -- Data for Name: account; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO account VALUES (1, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, 'Fortibase', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO account VALUES (2, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, 'FPS Production', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO account VALUES (3, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, 'Microsoft', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO account VALUES (4, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, 'Acme', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO account VALUES (1, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, false, 'Fortibase', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO account VALUES (2, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, false,'FPS Production', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO account VALUES (3, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, false,'Microsoft', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO account VALUES (4, '2014-12-12 14:41:40', '2014-12-12 14:41:40', NULL, true, false,'Acme', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 --


### PR DESCRIPTION
Hi,

This generates the correct `defaultValue` for boolean columns. I just started looking at the code, so let me know if things should be done differently.

Also, I saw the warning about not supporting SQL functions as a default value. I'm implementing support for `NOW()`, since it's so common and I need it for a project. Let me know if you're interested in this so I can send another pull request.