### PR TITLE
fix: was using table name instead of model name for "references" property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -296,11 +296,12 @@ function getColumnDetails(column) {
         defaultValue        : getSpecificConfig(column.table().name(), 'generate.columnDefault') && column.default() !== null ? clearDefaultValue(column.default()) : undefined,
         unique              : column.unique(),
         comment             : getSpecificConfig(column.table().name(), 'generate.columnDescription') ? column.description() : undefined,
-        references          : column.foreignKeyConstraint() ? column.foreignKeyConstraint().referencesTable().name() : undefined,
+        references          : column.foreignKeyConstraint() ? getModelNameFor(column.foreignKeyConstraint().referencesTable()) : undefined,
         referencesKey       : column.foreignKeyConstraint() ? column.foreignKeyConstraint().foreignKey(0).name() : undefined,
         onUpdate            : column.onUpdate(),
         onDelete            : column.onDelete()
     });
+
     result.type = column.sequelizeType(getSpecificConfig(column.table().name(), 'generate.dataTypeVariable')); // To prevent type having quotes.
     return result;
 }


### PR DESCRIPTION
References model name was using table name directly instead of
first converting with getModelNameFor().